### PR TITLE
CompatHelper: add new compat entry for DataFramesMeta at version 0.15, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,5 @@ SpeciesInteractionNetworks = "49e116ef-912f-4766-9e56-896a49944adc"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+DataFramesMeta = "0.15"
 SpeciesInteractionNetworks = "0.0.1"


### PR DESCRIPTION
This pull request sets the compat entry for the `DataFramesMeta` package to `0.15`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.