### PR TITLE
Add protection rules for species

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Extinctions = "cd114cb6-7982-4017-a01c-1032758e0eff"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"

--- a/docs/src/vignettes/introduction.jl
+++ b/docs/src/vignettes/introduction.jl
@@ -1,16 +1,14 @@
 # # Introduction
 
-# The goal of this project is simple: impliment different extinction mechanisms
+# The goal of this project is simple: implement different extinction mechanisms
 # for species interaction networks of the type `SpeciesInteractionNetworks`.
 # For now all extinction are secondary - *i.e.,* after the extinction of one
 # species we will also remove species that no longer have any prey (are unconnected).
-# However there is functionality for the order that the species are removed - 
-# *i.e.,* simulating different extinction mechanisms.
 
 # > note that this project is not officially hosted as a Julia package and so
 # > must be installed from github using 
 # > `Pkg.add https://github.com/TanyaS08/Extinctions.jl`. The same holds true
-# > for the `SpeciesInteractionNetworks`
+# > for `SpeciesInteractionNetworks`
 
 # **Random:** Species order is randomly determined.
 
@@ -20,11 +18,49 @@
 # **Numeric:** Order is determined by the numeric 'traits' of species *e.g.,* size.
 
 # In this example, we will see how the `Extinction.jl` package works by creating a
-# network using a iche model from the `SpeciesInteractionNetworks` package and
-# simulate a random extinction. 
+# network using the `SpeciesInteractionNetworks` package and start by simulating a 
+# random extinction. 
 
+using CairoMakie
 using Extinctions
 using SpeciesInteractionNetworks
 
 # First lets create a network:
 
+species = [:fox, :vole, :hawk, :turnip]
+nodes = Unipartite(species)
+
+int_matrix = Bool[
+    0 1 0 0;
+    0 0 0 1;
+    0 1 0 0;
+    0 0 0 0
+]
+edges = Binary(int_matrix)
+
+network = SpeciesInteractionNetwork(nodes, edges)
+
+# The default behaviour of the `extinctions()` function is to simulate random
+# extinctions until the richness of the entire network is zero. Additionally it
+# will protect all basal species from extinction (*i.e.,* only consumer species)
+# can be removed - but the basal species will eventually be removed as they
+# become disconnected from the 'core' network
+
+extinction_sequence = extinction(N)
+
+# Note we have every network at every time step of the extinction this is useful
+# if we want to *e.g.,* get the robustness of the network. Which we can do
+# using `robustness()`.
+
+robust = robustness(extinction_sequence)
+
+# we can also plot the extinction curve
+
+f = Figure()
+Axis(f[1,1], xlabel = "Proportion remaining",
+    ylabel = "Proportion removed")
+
+lines!(f[1,1], collect(LinRange(0.0, 1.0, length(extinction_sequence))),
+        richness.(extinction_sequence)./richness(first(extinction_sequence)))
+
+f

--- a/src/Extinctions.jl
+++ b/src/Extinctions.jl
@@ -10,6 +10,7 @@ include(joinpath("lib", "extinctionsequence.jl"))
 export extinctionsequence
 
 include(joinpath("lib", "speciesremoval.jl"))
+include(joinpath("lib", "protection.jl"))
 
 include(joinpath("lib", "extinction.jl"))
 

--- a/src/lib/extinction.jl
+++ b/src/lib/extinction.jl
@@ -19,22 +19,8 @@ function extinction(
     # get list for all species
     extinction_list = StatsBase.shuffle(SpeciesInteractionNetworks.species(N))
 
-    # get generality of all spp
-    gen = SpeciesInteractionNetworks.generality(N)
-
-    # we must protect basal species - remove them from extinction list
-    if protect == :basal
-        # identify basal species
-        filter!(v -> last(v) == 0, gen)
-        # remove the species previously identified as basal
-        filter!(x -> x ∉ collect(keys(gen)), extinction_list)
-    elseif protect == :consumer
-        # identify basal species
-        filter!(v -> last(v) > 0, gen)
-        # remove the species previously identified as basal
-        filter!(x -> x ∉ collect(keys(gen)), extinction_list)
-    end
-
+    # apply protection rules
+    extinction_list = _protect(N, protect, extinction_list)
     # create object to store networks at each timestamp
     network_series = Vector{SpeciesInteractionNetwork{<:Partiteness,<:Binary}}()
     # push initial network
@@ -69,6 +55,9 @@ function extinction(
    #         ),
    #     )
    # end
+
+   # apply protection rules
+   extinction_list = _protect(N, protect, extinction_list)
 
     network_series = Vector{SpeciesInteractionNetwork{<:Partiteness,<:Binary}}()
     # push initial network

--- a/src/lib/extinction.jl
+++ b/src/lib/extinction.jl
@@ -5,14 +5,37 @@ extinction(N::SpeciesInteractionNetwork, end_richness::Int64)
     the richness is less than or equal to that specified by `end_richness`.
 """
 function extinction(
-    N::SpeciesInteractionNetwork{<:Partiteness,<:Binary},
-    end_richness::Int64,
+    N::SpeciesInteractionNetwork{<:Partiteness,<:Binary};
+    end_richness::Int64 = 0,
+    protect::Symbol = :basal,
 )
     if richness(N) <= end_richness
         throw(ArgumentError("Richness of starting community is less than final community"))
     end
+    if protect ∉ [:none, :basal, :consumer]
+        error("Invalid value for protect -- must be :none, :basal or :consumer")
+    end
 
+    # get list for all species
     extinction_list = StatsBase.shuffle(SpeciesInteractionNetworks.species(N))
+
+    # get generality of all spp
+    gen = SpeciesInteractionNetworks.generality(N)
+
+    # we must protect basal species - remove them from extinction list
+    if protect == :basal
+        # identify basal species
+        filter!(v -> last(v) == 0, gen)
+        # remove the species previously identified as basal
+        filter!(x -> x ∉ collect(keys(gen)), extinction_list)
+    elseif protect == :consumer
+        # identify basal species
+        filter!(v -> last(v) > 0, gen)
+        # remove the species previously identified as basal
+        filter!(x -> x ∉ collect(keys(gen)), extinction_list)
+    end
+
+    # create object to store networks at each timestamp
     network_series = Vector{SpeciesInteractionNetwork{<:Partiteness,<:Binary}}()
     # push initial network
     push!(network_series, deepcopy(N))
@@ -36,7 +59,6 @@ function extinction(
     if richness(N) <= end_richness
         throw(ArgumentError("Richness of final community is less than starting community"))
     end
-    #check extinction method
     if protect ∉ [:none, :basal, :consumer]
         error("Invalid value for protect -- must be :none, :basal or :consumer")
     end

--- a/src/lib/extinction.jl
+++ b/src/lib/extinction.jl
@@ -2,7 +2,9 @@
 extinction(N::SpeciesInteractionNetwork, end_richness::Int64)
 
     Function to simulate random, cascading extinctions of an initial network `N` until 
-    the richness is less than or equal to that specified by `end_richness`.
+    the richness is less than or equal to that specified by `end_richness`. Protect
+    specifies which species should not be selected for extinction, by default all
+    basal species are protected
 """
 function extinction(
     N::SpeciesInteractionNetwork{<:Partiteness,<:Binary};

--- a/src/lib/extinction.jl
+++ b/src/lib/extinction.jl
@@ -29,11 +29,16 @@ extinction(N::SpeciesInteractionNetwork, extinction_list::Vector{String}, end_ri
 """
 function extinction(
     N::SpeciesInteractionNetwork{<:Partiteness,<:Binary},
-    extinction_list::Vector{Symbol},
-    end_richness::Int64,
+    extinction_list::Vector{Symbol};
+    end_richness::Int64 = 0,
+    protect::Symbol = :none,
 )
     if richness(N) <= end_richness
         throw(ArgumentError("Richness of final community is less than starting community"))
+    end
+    #check extinction method
+    if protect ∉ [:none, :basal, :consumer]
+        error("Invalid value for protect -- must be :none, :basal or :consumer")
     end
    # if !issubset(species(N), extinction_list)
    #     throw(

--- a/src/lib/protection.jl
+++ b/src/lib/protection.jl
@@ -5,7 +5,7 @@ _protect(N::SpeciesInteractionNetwork{<:Partiteness,<:Binary}, protect::Symbol, 
     be removed from the extinction sequence list - i.e. not targeted for
     extinction.
 """
-function _protect(N::SpeciesInteractionNetwork{<:Partiteness,<:Binary}, protect::Symbol, extinction_list::Vector{String})
+function _protect(N::SpeciesInteractionNetwork{<:Partiteness,<:Binary}, protect::Symbol, extinction_list::Vector{Symbol})
         # get generality of all spp
         gen = SpeciesInteractionNetworks.generality(N)
 

--- a/src/lib/protection.jl
+++ b/src/lib/protection.jl
@@ -1,0 +1,26 @@
+"""
+_protect(N::SpeciesInteractionNetwork{<:Partiteness,<:Binary}, protect::Symbol, extinction_list::Vector{String})
+
+    Internal for extinction function. Determines which species (if any) should
+    be removed from the extinction sequence list - i.e. not targeted for
+    extinction.
+"""
+function _protect(N::SpeciesInteractionNetwork{<:Partiteness,<:Binary}, protect::Symbol, extinction_list::Vector{String})
+        # get generality of all spp
+        gen = SpeciesInteractionNetworks.generality(N)
+
+        # we must protect basal species - remove them from extinction list
+        if protect == :basal
+            # identify basal species
+            filter!(v -> last(v) == 0, gen)
+            # remove the species previously identified as basal
+            filter!(x -> x ∉ collect(keys(gen)), extinction_list)
+        elseif protect == :consumer
+            # identify basal species
+            filter!(v -> last(v) > 0, gen)
+            # remove the species previously identified as basal
+            filter!(x -> x ∉ collect(keys(gen)), extinction_list)
+        end
+
+    return extinction_list
+end

--- a/src/lib/speciesremoval.jl
+++ b/src/lib/speciesremoval.jl
@@ -23,7 +23,8 @@ function _speciesremoval(
 
         # identify all species with generality of zero (no prey)
         gen = generality(K)
-        gen0 = collect(keys(filter(((k,v),) -> v == 0, gen)))
+        filter!(v -> last(v) == 0, gen)
+        gen0 = collect(keys(gen))
         # remove the species previously identified as basal
         filter!(x -> x ∉ basal_spp, gen0)
 


### PR DESCRIPTION
This addresses #8 

I see this panning out in two ways:

- [x] Need to specify if targeting only consumer or basal species when choosing species that go extinct - this should happen when creating the extinction sequence I'd say...
- [ ] I feel like there should be a protection clause somewhere but unsure where this would happen...